### PR TITLE
Synchronous mode for RS485 ModbusRTU (without asyncio)

### DIFF
--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -338,6 +338,7 @@ class ModbusBaseSyncClient(ModbusClientMixin[ModbusResponse]):
             parity=kwargs.get("parity", None),
             stopbits=kwargs.get("stopbits", None),
             handle_local_echo=kwargs.get("handle_local_echo", False),
+            rs485_settings=kwargs.get("rs485_settings", None),
         )
         self.params = self._params()
         self.params.retries = int(retries)

--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -16,7 +16,7 @@ from pymodbus.utilities import ModbusTransactionState
 
 try:
     import serial
-    from serial.rs485 import RS485Settings
+    from serial.rs485 import RS485Settings, RS485
     PYSERIAL_MISSING = False
 except ImportError:
     PYSERIAL_MISSING = True
@@ -211,15 +211,36 @@ class ModbusSerialClient(ModbusBaseSyncClient):
         if self.socket:
             return True
         try:
-            self.socket = serial.serial_for_url(
-                self.comm_params.host,
-                timeout=self.comm_params.timeout_connect,
-                bytesize=self.comm_params.bytesize,
-                stopbits=self.comm_params.stopbits,
-                baudrate=self.comm_params.baudrate,
-                parity=self.comm_params.parity,
-                exclusive=True,
-            )
+            # RS485 class is required (instead of Serial class) in case of Contec BXC200 device to use
+            # CPS-COM-PD2 for ModbusRTU communication.
+            # NOTE : This is not a fix for all device. It is intended to make CPS-COM-PD2 ModbusRTU 
+            # to work in synchronous manner (as of now the asynchronous way is already developed and 
+            # working as intended).
+
+            if self.comm_params.rs485_settings is not None:
+                self.socket = RS485(
+                    port=self.comm_params.host,
+                    timeout=self.comm_params.timeout_connect,
+                    bytesize=self.comm_params.bytesize,
+                    stopbits=self.comm_params.stopbits,
+                    baudrate=self.comm_params.baudrate,
+                    parity=self.comm_params.parity,
+                    exclusive=True,
+                )
+
+                # Is required
+                self.socket.rs485_mode = self.comm_params.rs485_settings
+            else:
+                self.socket = serial.serial_for_url(
+                    self.comm_params.host,
+                    timeout=self.comm_params.timeout_connect,
+                    bytesize=self.comm_params.bytesize,
+                    stopbits=self.comm_params.stopbits,
+                    baudrate=self.comm_params.baudrate,
+                    parity=self.comm_params.parity,
+                    exclusive=True,
+                )
+
             if self.strict:
                 self.socket.inter_byte_timeout = self.inter_byte_timeout
             self.last_frame_end = None


### PR DESCRIPTION
# Issue
The current implementation supports Modbus RTU communication over RS485, but only through the asynchronous AsyncModbusSerialClient (which depends on asyncio). For my use case, I want to avoid asynchronous methods entirely and use the synchronous ModbusSerialClient instead.
During testing, I found that ModbusSerialClient does not work correctly. The root cause is that an incorrect Serial class is being used. This PR fixes that issue.

# Root Cause
- serial.Serial class doesnt work in Contec CPS-COM-PD2, instead use serial.rs485.RS485 class
- rs485_settings is not properly passed to CommParams

# Testing
## Modbus synchronous reading code
```python
import asyncio
from serial import rs485
from pymodbus.client import ModbusSerialClient
import time

port = '/dev/ttyCom0'
def test_read_register():
    client = ModbusSerialClient(
        port=port,
        baudrate=9600,
        parity='E',
        bytesize=8,
        stopbits=1,
        timeout=0.1,
        rs485_settings=rs485.RS485Settings(rts_level_for_tx=True, rts_level_for_rx=False, delay_before_tx=0.01)
        )
    
    client.connect()

    for i in range(1000):
        response = client.read_input_registers(address=14, count=1, slave=31)
    
        if not response.isError():
            print(f"Read Holding Registers: {response.registers}")
        else:
            print(f"Error reading holding registers: {response}")
        time.sleep(0.25)

test_read_register()
```
## Expected Result
response.registers is printed as
```python
Read Holding Registers: [80]
```
## Actual Result
Using https://github.com/afterfit/pymodbus/commit/5f851ee7a758aad9b651e92eec295d74e820d8e3
```python
Error reading holding registers: Modbus Error: [Input/Output] Modbus Error: [Invalid Message] No response received, expected at least 4 bytes (0 received)
Error reading holding registers: Modbus Error: [Input/Output] No Response received from the remote slave/Unable to decode response
```

## After Fix Result
Using https://github.com/afterfit/pymodbus/commit/aa6952871ba1042c2017136511a02ce979e57881
```python
Read Holding Registers: [88]
Read Holding Registers: [88]
Read Holding Registers: [88]
Read Holding Registers: [72]
```

NOTE : This fix is for Contec CPS-COM-PD2 only. I have not confirmed it with any other device.